### PR TITLE
Enhancements to NMS used during epoch-by-epoch validation

### DIFF
--- a/tests/test_utils/test_bounding_box_utils.py
+++ b/tests/test_utils/test_bounding_box_utils.py
@@ -182,7 +182,12 @@ def test_bbox_nms():
         dtype=float32,
     )
 
-    nms_cfg = NMSConfig(min_confidence=0.5, min_iou=0.5, max_bbox=400)
+    nms_cfg = NMSConfig(
+        min_confidence=0.5,
+        min_iou=0.5,
+        max_bbox=400,
+        multi_label=True,
+    )
 
     # Batch 1:
     #  - box 1 is kept with classes 0 and 2 as it overlaps with box 4 and has a higher confidence for classes 0 and 2.

--- a/yolo/config/config.py
+++ b/yolo/config/config.py
@@ -136,6 +136,10 @@ class NMSConfig:
     min_confidence: float
     min_iou: float
     max_bbox: int
+    pre_topk: Optional[int] = 20000
+    multi_label: bool = False
+    class_agnostic: bool = False
+    size_bias_alpha: float = 0.0
 
 
 @dataclass

--- a/yolo/config/task/train.yaml
+++ b/yolo/config/task/train.yaml
@@ -122,7 +122,7 @@ loss:
     0.25
   matcher:
     iou: CIoU
-    topk: 20 # 10
+    topk: 10
     factor:
       iou: 6.0
       cls: 0.5

--- a/yolo/config/task/validation.yaml
+++ b/yolo/config/task/validation.yaml
@@ -9,7 +9,7 @@ data:
   data_augment: {}
   dynamic_shape: False
 nms:
-  min_confidence: 0.001 # 0.0001
+  min_confidence: 0.0001 # 0.0001
   min_iou: 0.7
   pre_topk: 20000 # pre-nms bboxes, Limit to top K pre-NMS per image (disable with None), (Default)None
   max_bbox: 20000 # post-nms bboxes, (Default)1000

--- a/yolo/config/task/validation.yaml
+++ b/yolo/config/task/validation.yaml
@@ -11,7 +11,15 @@ data:
 nms:
   min_confidence: 0.001 # 0.0001
   min_iou: 0.7
-  max_bbox: 1000
+  pre_topk: 20000 # pre-nms bboxes, Limit to top K pre-NMS per image (disable with None), (Default)None
+  max_bbox: 20000 # post-nms bboxes, (Default)1000
+  # multi_label=True: Expand all classes exceeding the threshold for a single anchor to "candidates"
+  # multi_label=False: Select only the top-ranked class per anchor as a candidate (= single-label)
+  # class_agnostic=True: NMS ignores classes and suppresses duplicates (rejects different classes even if they are in the same location)
+  # class_agnostic=False: NMS runs by class (different classes are not suppressed)
+  multi_label: True # True: multi-label expansion, (Default)False : Top-1 only
+  class_agnostic: True # True: Class-ignoring NMS, (Default)False: Class-specific NMS
+  size_bias_alpha: 0.0 # >0 to slightly increase large (e.g. 0.05)
 
 # Whether to print per-class mAP on validation end
 print_map_per_class: False
@@ -21,4 +29,4 @@ skip_metric_when_empty: True
 # Enable or disable the calculation of Loss/val_total
 # Calculating Loss/val_total consumes a large amount of VRAM,
 # so disabling logging can reduce VRAM consumption.
-calc_epoch_total_val_loss: True
+calc_epoch_total_val_loss: False

--- a/yolo/config/task/validation.yaml
+++ b/yolo/config/task/validation.yaml
@@ -13,12 +13,17 @@ nms:
   min_iou: 0.7
   pre_topk: 20000 # pre-nms bboxes, Limit to top K pre-NMS per image (disable with None), (Default)None
   max_bbox: 20000 # post-nms bboxes, (Default)1000
+
   # multi_label=True: Expand all classes exceeding the threshold for a single anchor to "candidates"
   # multi_label=False: Select only the top-ranked class per anchor as a candidate (= single-label)
   # class_agnostic=True: NMS ignores classes and suppresses duplicates (rejects different classes even if they are in the same location)
   # class_agnostic=False: NMS runs by class (different classes are not suppressed)
-  multi_label: True # True: multi-label expansion, (Default)False : Top-1 only
-  class_agnostic: True # True: Class-ignoring NMS, (Default)False: Class-specific NMS
+
+  # True: multi-label expansion, (Default)False : Top-1 only
+  multi_label: True
+  # (Default)True: Class-ignoring NMS, False: Class-specific NMS
+  # After training using a dataset with multiple classes defined in the same position and size, you should change it to False and re-run validation.
+  class_agnostic: True
   size_bias_alpha: 0.0 # >0 to slightly increase large (e.g. 0.05)
 
 # Whether to print per-class mAP on validation end

--- a/yolo/tools/solver.py
+++ b/yolo/tools/solver.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping
+from dataclasses import asdict, is_dataclass
 from math import ceil
 from pathlib import Path
 
@@ -408,11 +410,57 @@ class TrainModel(ValidateModel):
         super().__init__(cfg)
         self.cfg = cfg
         self.train_loader = create_dataloader(self.cfg.task.data, self.cfg.dataset, self.cfg.task.task)
+        self._nms_logged = False
 
     def setup(self, stage):
         super().setup(stage)
         if self.loss_fn is None:
             self.loss_fn = create_loss_function(self.cfg, self.vec2box)
+        if not self._nms_logged and (stage is None or stage == "fit"):
+            nms_cfg = getattr(self.validation_cfg, "nms", None)
+            if nms_cfg is not None:
+                nms_dict = None
+                if is_dataclass(nms_cfg):
+                    nms_dict = asdict(nms_cfg)
+                elif isinstance(nms_cfg, Mapping):
+                    nms_dict = dict(nms_cfg)
+                else:
+                    known_fields = (
+                        "min_confidence",
+                        "min_iou",
+                        "pre_topk",
+                        "max_bbox",
+                        "multi_label",
+                        "class_agnostic",
+                        "size_bias_alpha",
+                    )
+                    extracted = {key: getattr(nms_cfg, key) for key in known_fields if hasattr(nms_cfg, key)}
+                    if extracted:
+                        nms_dict = extracted
+
+                if nms_dict is not None:
+                    ordered_keys = [
+                        "min_confidence",
+                        "min_iou",
+                        "pre_topk",
+                        "max_bbox",
+                        "multi_label",
+                        "class_agnostic",
+                        "size_bias_alpha",
+                    ]
+                    summary = []
+                    for key in ordered_keys:
+                        if key in nms_dict:
+                            summary.append(f"{key}={nms_dict[key]}")
+                    for key, value in nms_dict.items():
+                        if key not in ordered_keys:
+                            summary.append(f"{key}={value}")
+                    nms_repr = ", ".join(summary) if summary else str(nms_dict)
+                else:
+                    nms_repr = str(nms_cfg)
+
+                logger.info(f":information_source: Validation NMS config: {nms_repr}")
+                self._nms_logged = True
         # Optional: load teacher for online KD
         self.kd_cfg = getattr(self.cfg.task, "kd", None)
         self.teacher = None

--- a/yolo/utils/bounding_box_utils.py
+++ b/yolo/utils/bounding_box_utils.py
@@ -558,10 +558,10 @@ def create_converter(
 
 
 def bbox_nms(
-    cls_dist: Tensor,              # [B, A, C] (logits または確率前)
-    bbox: Tensor,                  # [B, A, 4]  (xyxy, pixel座標)
-    nms_cfg,                       # .min_confidence, .min_iou, .max_bbox などを持つ設定
-    confidence: Tensor = None,     # [B, A] or [B, A, 1] (obj ロジット or 確率)
+    cls_dist: Tensor,              # [B, A, C] (logits or pre-probabilities)
+    bbox: Tensor,                  # [B, A, 4]  (xyxy, pixel coordinates)
+    nms_cfg,                       # configuration with min_confidence, min_iou, max_bbox, etc.
+    confidence: Tensor = None,     # [B, A] or [B, A, 1] (objectness logits or probabilities)
 ):
     B, A, C = cls_dist.shape
     device = cls_dist.device
@@ -589,18 +589,18 @@ def bbox_nms(
     class_agnostic = _cfg_value("class_agnostic", DEFAULT_CLASS_AGNOSTIC)
     size_bias_alpha = _cfg_value("size_bias_alpha", DEFAULT_SIZE_BIAS_ALPHA)
 
-    # obj（存在確率）
+    # objectness (existence probability)
     if confidence is None:
         obj = torch.ones((B, A, 1), device=device, dtype=dtype)
     else:
         obj = confidence
         if obj.ndim == 2:
             obj = obj.unsqueeze(-1)
-        # ロジットが来る場合にも対応（0..1 に正規化）
+        # convert logits to probabilities in [0, 1]
         if obj.min() < 0 or obj.max() > 1:
             obj = obj.sigmoid()
 
-    # クラス確率
+    # class probabilities
     prob = cls_dist
     if prob.min() < 0 or prob.max() > 1:
         prob = prob.sigmoid()
@@ -612,18 +612,18 @@ def bbox_nms(
         oi = obj[i]         # [A, 1]
 
         if not multi_label:
-            # ---- Single-label（安定） ----
+            # ---- Single-label (stable path) ----
             cls_p, cls_id = pi.max(dim=1, keepdim=True)               # [A,1], [A,1]
             score = (cls_p * oi).squeeze(1)                           # [A]
 
-            # サイズバイアス（任意）
+            # optional size bias
             if size_bias_alpha != 0.0:
                 w = (bi[:, 2] - bi[:, 0]).clamp_(min=0)
                 h = (bi[:, 3] - bi[:, 1]).clamp_(min=0)
                 area = (w * h).clamp_(min=1.0)
                 score = score * (area ** size_bias_alpha)
 
-            # conf しきい値
+            # confidence thresholding
             keep = score > nms_cfg.min_confidence
             if keep.sum() == 0:
                 outputs.append(bi.new_zeros((0, 6)))
@@ -631,18 +631,18 @@ def bbox_nms(
 
             bi, score, cls_id = bi[keep], score[keep], cls_id[keep].squeeze(1)
 
-            # pre-NMS 上位K（スコア順）
+            # pre-NMS top-K (sorted by score)
             if pre_topk is not None and bi.size(0) > pre_topk:
                 topk_idx = score.topk(pre_topk).indices
                 bi = bi.index_select(0, topk_idx)
                 score = score.index_select(0, topk_idx)
                 cls_id = cls_id.index_select(0, topk_idx)
 
-            # NMS（クラス別 or クラス無視）
+            # NMS (class-wise or class-agnostic)
             ids = torch.zeros_like(cls_id) if class_agnostic else cls_id
             keep_idx = batched_nms(bi, score, ids, nms_cfg.min_iou)
 
-            # スコアで再ソート → [:max_bbox]
+            # resort by score → [:max_bbox]
             keep_idx = keep_idx[: nms_cfg.max_bbox]
             si = score.index_select(0, keep_idx)
             ci = cls_id.index_select(0, keep_idx).to(torch.int64)
@@ -652,8 +652,8 @@ def bbox_nms(
             outputs.append(pred)
 
         else:
-            # ---- Multi-label（必要なときのみ）----
-            # 展開：閾値超の (anchor, class) を列挙
+            # ---- Multi-label (only when requested) ----
+            # enumerate (anchor, class) pairs above the threshold
             score_mat = pi * oi                                  # [A, C]
             ai, ci = torch.where(score_mat > nms_cfg.min_confidence)
             if ai.numel() == 0:
@@ -662,14 +662,14 @@ def bbox_nms(
 
             si = score_mat[ai, ci]                               # [N]
             b2 = bi[ai]                                          # [N, 4]
-            # サイズバイアス
+            # size bias
             if size_bias_alpha != 0.0:
                 w = (b2[:, 2] - b2[:, 0]).clamp_(min=0)
                 h = (b2[:, 3] - b2[:, 1]).clamp_(min=0)
                 area = (w * h).clamp_(min=1.0)
                 si = si * (area ** size_bias_alpha)
 
-            # pre-NMS 上位K
+            # pre-NMS top-K
             if pre_topk is not None and si.size(0) > pre_topk:
                 topk_idx = si.topk(pre_topk).indices
                 b2 = b2.index_select(0, topk_idx)
@@ -679,7 +679,7 @@ def bbox_nms(
             ids = torch.zeros_like(ci) if class_agnostic else ci
             keep_idx = batched_nms(b2, si, ids, nms_cfg.min_iou)
 
-            # スコアで再ソート → [:max_bbox]
+            # resort by score → [:max_bbox]
             keep_idx = keep_idx[: nms_cfg.max_bbox]
             out = torch.cat([ci.index_select(0, keep_idx)[:, None].to(b2.dtype),
                              b2.index_select(0, keep_idx),

--- a/yolo/utils/bounding_box_utils.py
+++ b/yolo/utils/bounding_box_utils.py
@@ -557,24 +557,136 @@ def create_converter(
     return Vec2Box(model, anchor_cfg, image_size, device)
 
 
-def bbox_nms(cls_dist: Tensor, bbox: Tensor, nms_cfg: NMSConfig, confidence: Optional[Tensor] = None):
-    cls_dist = cls_dist.sigmoid() * (1 if confidence is None else confidence)
+def bbox_nms(
+    cls_dist: Tensor,              # [B, A, C] (logits または確率前)
+    bbox: Tensor,                  # [B, A, 4]  (xyxy, pixel座標)
+    nms_cfg,                       # .min_confidence, .min_iou, .max_bbox などを持つ設定
+    confidence: Tensor = None,     # [B, A] or [B, A, 1] (obj ロジット or 確率)
+):
+    B, A, C = cls_dist.shape
+    device = cls_dist.device
+    dtype = cls_dist.dtype
 
-    batch_idx, valid_grid, valid_cls = torch.where(cls_dist > nms_cfg.min_confidence)
-    valid_con = cls_dist[batch_idx, valid_grid, valid_cls]
-    valid_box = bbox[batch_idx, valid_grid]
+    DEFAULT_PRE_TOPK = 20000
+    DEFAULT_MULTI_LABEL = False
+    DEFAULT_CLASS_AGNOSTIC = False
+    DEFAULT_SIZE_BIAS_ALPHA = 0.0
 
-    nms_idx = batched_nms(valid_box, valid_con, batch_idx + valid_cls * bbox.size(0), nms_cfg.min_iou)
-    predicts_nms = []
-    for idx in range(cls_dist.size(0)):
-        instance_idx = nms_idx[idx == batch_idx[nms_idx]]
+    def _cfg_value(name: str, default):
+        if nms_cfg is None:
+            return default
+        if hasattr(nms_cfg, name):
+            return getattr(nms_cfg, name)
+        if isinstance(nms_cfg, dict):
+            return nms_cfg.get(name, default)
+        try:
+            return nms_cfg[name]
+        except (TypeError, KeyError, IndexError):
+            return default
 
-        predict_nms = torch.cat(
-            [valid_cls[instance_idx][:, None], valid_box[instance_idx], valid_con[instance_idx][:, None]], dim=-1
-        )
+    pre_topk = _cfg_value("pre_topk", DEFAULT_PRE_TOPK)
+    multi_label = _cfg_value("multi_label", DEFAULT_MULTI_LABEL)
+    class_agnostic = _cfg_value("class_agnostic", DEFAULT_CLASS_AGNOSTIC)
+    size_bias_alpha = _cfg_value("size_bias_alpha", DEFAULT_SIZE_BIAS_ALPHA)
 
-        predicts_nms.append(predict_nms[: nms_cfg.max_bbox])
-    return predicts_nms
+    # obj（存在確率）
+    if confidence is None:
+        obj = torch.ones((B, A, 1), device=device, dtype=dtype)
+    else:
+        obj = confidence
+        if obj.ndim == 2:
+            obj = obj.unsqueeze(-1)
+        # ロジットが来る場合にも対応（0..1 に正規化）
+        if obj.min() < 0 or obj.max() > 1:
+            obj = obj.sigmoid()
+
+    # クラス確率
+    prob = cls_dist
+    if prob.min() < 0 or prob.max() > 1:
+        prob = prob.sigmoid()
+
+    outputs = []
+    for i in range(B):
+        pi = prob[i]        # [A, C]
+        bi = bbox[i]        # [A, 4]
+        oi = obj[i]         # [A, 1]
+
+        if not multi_label:
+            # ---- Single-label（安定） ----
+            cls_p, cls_id = pi.max(dim=1, keepdim=True)               # [A,1], [A,1]
+            score = (cls_p * oi).squeeze(1)                           # [A]
+
+            # サイズバイアス（任意）
+            if size_bias_alpha != 0.0:
+                w = (bi[:, 2] - bi[:, 0]).clamp_(min=0)
+                h = (bi[:, 3] - bi[:, 1]).clamp_(min=0)
+                area = (w * h).clamp_(min=1.0)
+                score = score * (area ** size_bias_alpha)
+
+            # conf しきい値
+            keep = score > nms_cfg.min_confidence
+            if keep.sum() == 0:
+                outputs.append(bi.new_zeros((0, 6)))
+                continue
+
+            bi, score, cls_id = bi[keep], score[keep], cls_id[keep].squeeze(1)
+
+            # pre-NMS 上位K（スコア順）
+            if pre_topk is not None and bi.size(0) > pre_topk:
+                topk_idx = score.topk(pre_topk).indices
+                bi = bi.index_select(0, topk_idx)
+                score = score.index_select(0, topk_idx)
+                cls_id = cls_id.index_select(0, topk_idx)
+
+            # NMS（クラス別 or クラス無視）
+            ids = torch.zeros_like(cls_id) if class_agnostic else cls_id
+            keep_idx = batched_nms(bi, score, ids, nms_cfg.min_iou)
+
+            # スコアで再ソート → [:max_bbox]
+            keep_idx = keep_idx[: nms_cfg.max_bbox]
+            si = score.index_select(0, keep_idx)
+            ci = cls_id.index_select(0, keep_idx).to(torch.int64)
+            bi = bi.index_select(0, keep_idx)
+
+            pred = torch.cat([ci[:, None].to(bi.dtype), bi, si[:, None]], dim=1)  # [N, 6]
+            outputs.append(pred)
+
+        else:
+            # ---- Multi-label（必要なときのみ）----
+            # 展開：閾値超の (anchor, class) を列挙
+            score_mat = pi * oi                                  # [A, C]
+            ai, ci = torch.where(score_mat > nms_cfg.min_confidence)
+            if ai.numel() == 0:
+                outputs.append(bi.new_zeros((0, 6)))
+                continue
+
+            si = score_mat[ai, ci]                               # [N]
+            b2 = bi[ai]                                          # [N, 4]
+            # サイズバイアス
+            if size_bias_alpha != 0.0:
+                w = (b2[:, 2] - b2[:, 0]).clamp_(min=0)
+                h = (b2[:, 3] - b2[:, 1]).clamp_(min=0)
+                area = (w * h).clamp_(min=1.0)
+                si = si * (area ** size_bias_alpha)
+
+            # pre-NMS 上位K
+            if pre_topk is not None and si.size(0) > pre_topk:
+                topk_idx = si.topk(pre_topk).indices
+                b2 = b2.index_select(0, topk_idx)
+                si = si.index_select(0, topk_idx)
+                ci = ci.index_select(0, topk_idx)
+
+            ids = torch.zeros_like(ci) if class_agnostic else ci
+            keep_idx = batched_nms(b2, si, ids, nms_cfg.min_iou)
+
+            # スコアで再ソート → [:max_bbox]
+            keep_idx = keep_idx[: nms_cfg.max_bbox]
+            out = torch.cat([ci.index_select(0, keep_idx)[:, None].to(b2.dtype),
+                             b2.index_select(0, keep_idx),
+                             si.index_select(0, keep_idx)[:, None]], dim=1)
+            outputs.append(out)
+
+    return outputs
 
 
 def calculate_map(predictions, ground_truths) -> Dict[str, Tensor]:


### PR DESCRIPTION
```yaml
nms:
  min_confidence: 0.0001 # 0.0001
  min_iou: 0.7
  pre_topk: 20000 # pre-nms bboxes, Limit to top K pre-NMS per image (disable with None), (Default)None
  max_bbox: 20000 # post-nms bboxes, (Default)1000

  # multi_label=True: Expand all classes exceeding the threshold for a single anchor to "candidates"
  # multi_label=False: Select only the top-ranked class per anchor as a candidate (= single-label)
  # class_agnostic=True: NMS ignores classes and suppresses duplicates (rejects different classes even if they are in the same location)
  # class_agnostic=False: NMS runs by class (different classes are not suppressed)

  # True: multi-label expansion, (Default)False : Top-1 only
  multi_label: True
  # (Default)True: Class-ignoring NMS, False: Class-specific NMS
  # After training using a dataset with multiple classes defined in the same position and size, you should change it to False and re-run validation.
  class_agnostic: True
  size_bias_alpha: 0.0 # >0 to slightly increase large (e.g. 0.05)
```